### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
   - 7.2
   - 7.3
 
-sudo: required
-
 install: composer install
 
 before_script:

--- a/tests/Cases/ManagerTest.php
+++ b/tests/Cases/ManagerTest.php
@@ -12,63 +12,63 @@ class ManagerTest extends BaseCase
 {
     public function testGetInsstance()
     {
-        $insstnace = Manager::getInstance();
+        $instance = Manager::getInstance();
 
-        $this->assertInstanceOf(Manager::class, $insstnace);
+        $this->assertInstanceOf(Manager::class, $instance);
     }
 
-    public function testConstruct()
+    public function testConstructor()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
-        $this->assertInstanceOf(Manager::class, $insstnace);
+        $this->assertInstanceOf(Manager::class, $instance);
 
-        $insstnace = new Manager($this->pdo);
+        $instance = new Manager($this->pdo);
 
-        $this->assertInstanceOf(Manager::class, $insstnace);
+        $this->assertInstanceOf(Manager::class, $instance);
     }
 
     public function testAddConnection()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
-        
-        $connection = $insstnace->getConnection();
+        $instance->addConnection($pdo);
+
+        $connection = $instance->getConnection();
 
         $this->assertInstanceOf(Connection::class, $connection);
     }
 
     public function testAddMapper()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
         $this->assertInstanceOf(PlanMapper::class, $mapper);
     }
 
     public function testGetdMapper()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $this->assertInstanceOf(PlanMapper::class, $mapper);
     }

--- a/tests/Cases/MapperTest.php
+++ b/tests/Cases/MapperTest.php
@@ -12,32 +12,32 @@ class MapperTest extends BaseCase
 {
     public function testConstructor()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
         $this->assertInstanceOf(PlanMapper::class, $mapper);
     }
 
     public function testFind()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $plan = $mapper->find(1);
 
@@ -47,17 +47,17 @@ class MapperTest extends BaseCase
 
     public function testWhere()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $collection = $mapper->where(['id' => 1]);
 
@@ -66,17 +66,17 @@ class MapperTest extends BaseCase
 
     public function testOr()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $collection = $mapper->or(['id' => 1, 'name' => 'intro']);
 
@@ -86,17 +86,17 @@ class MapperTest extends BaseCase
 
     public function testAll()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $collection = $mapper->all();
 
@@ -105,19 +105,19 @@ class MapperTest extends BaseCase
 
     public function testHydrator()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $hydrator = new PlanHydratorProxy();
 
         $mapper = new PlanMapper(Plan::class, null, $hydrator);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $collection = $mapper->all();
 
@@ -126,17 +126,17 @@ class MapperTest extends BaseCase
 
     public function testStore()
     {
-        $insstnace = new Manager();
+        $instance = new Manager();
 
         $pdo = $this->pdo;
 
-        $insstnace->addConnection($pdo);
+        $instance->addConnection($pdo);
 
         $mapper = new PlanMapper(Plan::class);
 
-        $insstnace->addMapper(Plan::class, $mapper);
+        $instance->addMapper(Plan::class, $mapper);
 
-        $mapper = $insstnace->getMapper(Plan::class);
+        $mapper = $instance->getMapper(Plan::class);
 
         $plan = new Plan();
 

--- a/tests/Cases/System/ConnectionTest.php
+++ b/tests/Cases/System/ConnectionTest.php
@@ -8,6 +8,8 @@ use RuntimeException;
 
 class ConnectionTest extends TestCase
 {
+    protected $conn;
+
     public function testConstructor()
     {
         $config = [
@@ -15,14 +17,14 @@ class ConnectionTest extends TestCase
             'path' => 'memory',
         ];
 
-        $conn = new Connection($config);
+        $this->conn = new Connection($config);
 
-        $this->assertInstanceOf(Connection::class, $conn);
+        $this->assertInstanceOf(Connection::class, $this->conn);
 
-        $conn->connect();
+        $this->conn->connect();
     }
 
-    public function testConnect()
+    public function testConnectOnIncorrectConfig()
     {
         $config = [
             'driver' => 'mysql',
@@ -32,24 +34,65 @@ class ConnectionTest extends TestCase
             'dbname' => 'testdb',
         ];
 
-        $conn = new Connection($config);
+        $this->conn = new Connection($config);
 
-        $this->assertInstanceOf(Connection::class, $conn);
+        $this->assertInstanceOf(Connection::class, $this->conn);
         $this->expectException(RunTimeException::class);
-        $conn->connect();
+        $this->conn->connect();
+    }
 
-        $conn = null;
-
-        $config2 = [
+    public function testConnectOnCorrectConfig()
+    {
+        $config = [
             'driver' => 'sqlite',
             'path' => 'memory',
         ];
 
-        $conn2 = new Connection($config2);
+        $this->conn = new Connection($config);
 
-        $this->assertInstanceOf(Connection::class, $conn2);
+        $this->assertInstanceOf(Connection::class, $this->conn);
 
-        $conn2->connect();
-        $conn2->disconnect();
+        $this->conn->connect();
+        $this->conn->disconnect();
+    }
+
+    public function testConnectOnDuplicatedConnection()
+    {
+        $config = [
+            'driver' => 'sqlite',
+            'path' => 'memory',
+        ];
+
+        $this->conn = new Connection($config);
+
+        $this->assertInstanceOf(Connection::class, $this->conn);
+
+        $this->conn->connect();
+
+        $this->assertNull($this->conn->connect());
+
+        $this->conn->disconnect();
+    }
+
+    public function testDisconnect()
+    {
+        $config = [
+            'driver' => 'sqlite',
+            'path' => 'memory',
+        ];
+
+        $this->conn = new Connection($config);
+
+        $this->conn->connect();
+        $this->conn->disconnect();
+
+        $this->assertInstanceOf(Connection::class, $this->conn->connect());
+
+        $this->conn->disconnect();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->conn = null;
     }
 }


### PR DESCRIPTION
# Changed log
- Fix `$instance` typo.
- In `.travis.yml` setting, the default root privilege user is closed. Removing the `sudo: required` is fine.
- Reorganize the `Connection` class test. It includes:
  - `connect` method with incorrect database config test.
  - `connect` method with correct database config test.
  - `disconnect` method test.
